### PR TITLE
Togglable UPNP, better error handling and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@ npm install @silentbot1/nat-api
 ```js
 const NatAPI = require('nat-api')
 
-// For NAT-UPNP only, use:
-const client = new NatAPI()
-
 // For NAT-PMP + NAT-UPNP, use:
-const client = new NatAPI({ enablePMP: true })
+const client = new NatAPI({ enablePMP: true, enableUPNP: true })
 
 // Map public port 1000 to private port 1000 with UDP and TCP
 client.map(1000).then(() => {
@@ -62,7 +59,7 @@ client.externalIp().then((ip) => {
 })
 
 // Destroy object
-client.destroy().then((ip) => {
+client.destroy().then(() => {
   console.log('Client has been destroyed!')
 }).catch((err) => {
   return console.log('Error', err)
@@ -82,7 +79,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
   ttl: 1200, // Time to live of each port mapping in seconds (default: 1200)
   autoUpdate: true, // Refresh all the port mapping to keep them from expiring (default: true)
   gateway: '192.168.1.1', // Default gateway (default: null)
-  enablePMP: false // Enable PMP (default: false)
+  enablePMP: false // Enable PMP (default: true)
+  enableUPNP: false // Enable UPNP (default: true)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class NatAPI {
     this._pmpIntervals = {}
 
     // Setup NAT-PMP Client
-    this.enablePMP = !!opts.enablePMP
+    this.enablePMP = opts.enablePMP !== false
     if (this.enablePMP) {
       try {
         // Lookup gateway IP
@@ -43,7 +43,7 @@ class NatAPI {
       this._pmpClient = null
     }
 
-    this.enableUPNP = !!opts.enableUPNP
+    this.enableUPNP = opts.enableUPNP !== false
     if (this.enableUPNP) {
       // Setup UPnP Client
       this._upnpClient = NatUPNP.createClient()

--- a/lib/upnp/index.js
+++ b/lib/upnp/index.js
@@ -1,6 +1,3 @@
-const async = require('async')
-
-const Device = require('./device')
 const Ssdp = require('./ssdp')
 
 class Client {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "async": "^3.2.4",
     "debug": "^4.3.4",
     "default-gateway": "^6.0.3",
     "node-fetch": "^2.6.9",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.1",
+  "version": "0.4.2",
   "name": "@silentbot1/nat-api",
   "description": "Port mapping with UPnP and NAT-PMP",
   "main": "index.js",


### PR DESCRIPTION
This PR implements the following features:
- Add: Togglable UPNP via `enableUPNP` option.
- Add: Ability to get errors when calling `_map` or `_unmap` directly.
- Fix: allow `externalIp` calls, when PMP is enabled, to correctly times out.
- Fix: Better error handling/catching.
- Fix: Remove unused dependency `async`.