### PR TITLE
Update _openPorts flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,26 +71,26 @@ export default class NatAPI {
 
     if (opts.protocol) {
       // UDP or TCP
-      const response = await this._map(opts)
-      if (!response[0]) return false
       const newOpts = { ...opts }
       this._openPorts.push(newOpts)
+      const response = await this._map(opts)
+      if (!response[0]) return false
     } else {
       // UDP & TCP
 
       // Map UDP
       const newOptsUDP = { ...opts }
       newOptsUDP.protocol = 'UDP'
+      this._openPorts.push(newOptsUDP)
       let response = await this._map(newOptsUDP)
       if (!response[0]) return false
-      this._openPorts.push(newOptsUDP)
 
       // Map TCP
       const newOptsTCP = { ...opts }
       newOptsTCP.protocol = 'TCP'
+      this._openPorts.push(newOptsTCP)
       response = await this._map(newOptsTCP)
       if (!response[0]) return false
-      this._openPorts.push(newOptsTCP)
     }
     return true
   }

--- a/index.js
+++ b/index.js
@@ -74,7 +74,14 @@ export default class NatAPI {
       const newOpts = { ...opts }
       this._openPorts.push(newOpts)
       const response = await this._map(opts)
-      if (!response[0]) return false
+      if (!response[0]) {
+        arrayRemove(this._openPorts, this._openPorts.findIndex((o) => {
+          return (o.publicPort === opts.publicPort) &&
+            (o.privatePort === opts.privatePort) &&
+            (o.protocol === opts.protocol || opts.protocol == null)
+        }))
+        return false
+      }
     } else {
       // UDP & TCP
 
@@ -83,14 +90,28 @@ export default class NatAPI {
       newOptsUDP.protocol = 'UDP'
       this._openPorts.push(newOptsUDP)
       let response = await this._map(newOptsUDP)
-      if (!response[0]) return false
+      if (!response[0]) {
+        arrayRemove(this._openPorts, this._openPorts.findIndex((o) => {
+          return (o.publicPort === newOptsUDP.publicPort) &&
+            (o.privatePort === newOptsUDP.privatePort) &&
+            (o.protocol === newOptsUDP.protocol || newOptsUDP.protocol == null)
+        }))
+        return false
+      }
 
       // Map TCP
       const newOptsTCP = { ...opts }
       newOptsTCP.protocol = 'TCP'
       this._openPorts.push(newOptsTCP)
       response = await this._map(newOptsTCP)
-      if (!response[0]) return false
+      if (!response[0]) {
+        arrayRemove(this._openPorts, this._openPorts.findIndex((o) => {
+          return (o.publicPort === newOptsTCP.publicPort) &&
+            (o.privatePort === newOptsTCP.privatePort) &&
+            (o.protocol === newOptsTCP.protocol || newOptsTCP.protocol == null)
+        }))
+        return false
+      }
     }
     return true
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.3",
+  "version": "0.4.4",
   "name": "@silentbot1/nat-api",
   "description": "Port mapping with UPnP and NAT-PMP",
   "main": "index.js",


### PR DESCRIPTION
This PR updates how port mappings are handled, first adding them to `_openPorts` before the mapping has succeeded, and removing these if the port mapping fails. This allows us to account for situations where `destroy()` may be called before the mapping has succeeded.