### PR TITLE
Fix PMP socket closure

### DIFF
--- a/lib/pmp/index.js
+++ b/lib/pmp/index.js
@@ -91,7 +91,14 @@ export default class Client extends EventEmitter {
   async close () {
     debug('Client#close()')
     if (this.socket) {
-      await new Promise(resolve => this.socket.close(resolve))
+      await new Promise(resolve => {
+        try {
+          this.socket.close(resolve)
+        } catch (error) {
+          resolve()
+          // Discard Error
+        }
+      })
     }
     this.socket = null
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.6",
+  "version": "0.4.7",
   "name": "@silentbot1/nat-api",
   "description": "Port mapping with UPnP and NAT-PMP",
   "main": "index.js",


### PR DESCRIPTION
This PR wraps socket.close within PMMP with a try catch to catch edge cases in destruction and bumps the version ready for publishing.